### PR TITLE
ci: update workflow to run on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,8 @@ jobs:
       - name: Run validation tests
         run: npm run test
 
-      - name: Get branch names
-        id: branch-name
-        uses: tj-actions/branch-names@v6
-
       - name: Set $refs to remote on merge and update $ids
-        if: steps.branch-name.outputs.is_default == 'true' && github.event_name != 'release'
+        if: github.event_name == 'closed' && github.event.pull_request.merged == 'true'
         run: |
           npm run update:refs -- --environment remote --stage true
           npm run update:version --stage true
@@ -77,7 +73,7 @@ jobs:
 
       - name: Add, commit and push updated definitions
         id: commit-definitions
-        if: steps.branch-name.outputs.is_default == 'true' && github.event_name != 'release'
+        if: github.event_name == 'closed' && github.event.pull_request.merged == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: 'chore: update $refs to remote urls [skip ci]'


### PR DESCRIPTION
# Description

Update `ci` to update refs and ids when a PR is merged, as the current implementation is to update them on push to `main`, but as `main` is a protected branch, that doesn't work.

## Type of change

Please delete options that are not relevant.

- [x] CI workflow update 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] ⚠️ I ensured that the changes to the schema will be compatible with [schema-tools library](https://github.com/s1seven/schema-tools)
