### PR TITLE
feat: add RefSchemaUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Each folder should have a `test` folder with a `test-suites-map.js` file and a `
 When a new folder is created and tests are added, the folder name must be added to the `folders` array in `validate.spec.js`.
 It must also be added to the `folders` array in `constants.js`. A new object should be added to `schemaFilePaths` in `update-version.js`, using the existing objects as a template.
 
-If, in the unlikely case that the new definition references other definitions, it much be added to `refMap` in `constants.js`, with the schema definition name being the `property` and the `value` being an array containing the names of the referenced definitions such as `'commercial-transaction': ['KeyValueObject', 'Company'],`;
+If, in the unlikely case that the new definition references other definitions, it must be added to `refMap` in `constants.js`, with the schema definition name being the `property` and the `value` being an array containing the names of the referenced definitions such as `'commercial-transaction': ['KeyValueObject', 'Company'],`;
 
 # Creating a new release
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ There should also be a `test-schema.json` in each folder which references the ma
 Each folder should have a `test` folder with a `test-suites-map.js` file and a `fixtures` folder within. The `test-suites-map.js` file should contain a map of the valid and invalid certificates contained within the `fixtures` folder for testing, as well as the errors expected for the invalid certificates.
 
 When a new folder is created and tests are added, the folder name must be added to the `folders` array in `validate.spec.js`.
+It must also be added to the `folders` array in `constants.js`. A new object should be added to `schemaFilePaths` in `update-version.js`, using the existing objects as a template.
+
+If, in the unlikely case that the new definition references other definitions, it much be added to `refMap` in `constants.js`, with the schema definition name being the `property` and the `value` being an array containing the names of the referenced definitions such as `'commercial-transaction': ['KeyValueObject', 'Company'],`;
 
 # Creating a new release
 

--- a/attachment/attachment.json
+++ b/attachment/attachment.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/attachment/attachment.json",
+  "$id": "attachment.json",
   "definitions": {
     "Hash": {
       "title": "Hash",
@@ -10,19 +10,13 @@
         "Algorithm": {
           "description": "The algorithm selected to calculate the hash value.",
           "type": "string",
-          "enum": [
-            "SHA256",
-            "SHA3-256"
-          ],
+          "enum": ["SHA256", "SHA3-256"],
           "default": "SHA256"
         },
         "Encoding": {
           "description": "The format in which the hash value is encoded.",
           "type": "string",
-          "enum": [
-            "base64",
-            "hex"
-          ],
+          "enum": ["base64", "hex"],
           "default": "base64"
         },
         "Value": {
@@ -30,11 +24,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "Algorithm",
-        "Encoding",
-        "Value"
-      ]
+      "required": ["Algorithm", "Encoding", "Value"]
     },
     "Attachment": {
       "title": "Attachment",
@@ -48,39 +38,24 @@
         "FileName": {
           "description": "The name of the file.",
           "type": "string",
-          "examples": [
-            "file.pdf"
-          ]
+          "examples": ["file.pdf"]
         },
         "MIME-Type": {
           "description": "The MIME/Type of the data file.",
           "type": "string",
-          "examples": [
-            "application/json",
-            "application/pdf",
-            "image/png"
-          ]
+          "examples": ["application/json", "application/pdf", "image/png"]
         },
         "Encoding": {
           "description": "The format in which the hash value is encoded.",
           "type": "string",
-          "examples": [
-            "base64",
-            "hex"
-          ]
+          "examples": ["base64", "hex"]
         },
         "Data": {
           "description": "The data encoded as defined in `Encoding`",
           "type": "string"
         }
       },
-      "required": [
-        "Hash",
-        "FileName",
-        "MIME-Type",
-        "Encoding",
-        "Data"
-      ],
+      "required": ["Hash", "FileName", "MIME-Type", "Encoding", "Data"],
       "additionalProperties": false
     }
   }

--- a/chemical-element/chemical-element.json
+++ b/chemical-element/chemical-element.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/chemical-element/chemical-element.json",
+  "$id": "chemical-element.json",
   "definitions": {
     "ChemicalElement": {
       "title": "ChemicalElement",
@@ -30,10 +30,7 @@
           "maximum": 100
         }
       },
-      "required": [
-        "Symbol",
-        "Actual"
-      ],
+      "required": ["Symbol", "Actual"],
       "additionalProperties": false
     }
   }

--- a/commercial-transaction/commercial-transaction.json
+++ b/commercial-transaction/commercial-transaction.json
@@ -1,18 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/commercial-transaction/commercial-transaction.json",
+  "$id": "commercial-transaction.json",
   "definitions": {
     "Company": {
       "allOf": [
         {
-          "$ref": "https://schemas.s1seven.com/schema-definitions/v0.0.5/company/company.json#/definitions/Company"
+          "$ref": "../company.json#/definitions/Company"
         }
       ]
     },
     "KeyValueObject": {
       "allOf": [
         {
-          "$ref": "https://schemas.s1seven.com/schema-definitions/v0.0.5/key-value-object/key-value-object.json#/definitions/KeyValueObject"
+          "$ref": "../key-value-object.json#/definitions/KeyValueObject"
         }
       ]
     },

--- a/company/company.json
+++ b/company/company.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/company/company.json",
+  "$id": "company.json",
   "definitions": {
     "CompanyBase": {
       "type": "object",
@@ -17,14 +17,7 @@
           "minLength": 2,
           "maxLength": 2,
           "pattern": "^[A-Z]{2}$",
-          "examples": [
-            "AT",
-            "DE",
-            "FR",
-            "ES",
-            "PL",
-            "CN"
-          ]
+          "examples": ["AT", "DE", "FR", "ES", "PL", "CN"]
         },
         "Email": {
           "type": "string",
@@ -47,9 +40,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "Name"
-          ]
+          "required": ["Name"]
         },
         {
           "properties": {
@@ -57,16 +48,10 @@
               "type": "string"
             }
           },
-          "required": [
-            "CompanyName"
-          ]
+          "required": ["CompanyName"]
         }
       ],
-      "required": [
-        "ZipCode",
-        "City",
-        "Country"
-      ],
+      "required": ["ZipCode", "City", "Country"],
       "additionalProperties": true
     },
     "CompanyAddress": {
@@ -89,9 +74,7 @@
           ]
         }
       },
-      "required": [
-        "Street"
-      ]
+      "required": ["Street"]
     },
     "CompanyIdentifiers": {
       "type": "object",
@@ -99,9 +82,7 @@
         "CageCode": {
           "description": "The Commercial and Government Entity Code (short CAG), is a unique identifier assigned to suppliers to various government or defense agencies, https://en.wikipedia.org/wiki/Commercial_and_Government_Entity_code",
           "type": "string",
-          "examples": [
-            "N1950#"
-          ]
+          "examples": ["N1950#"]
         }
       },
       "anyOf": [
@@ -113,9 +94,7 @@
               "maxLength": 15
             }
           },
-          "required": [
-            "VAT"
-          ]
+          "required": ["VAT"]
         },
         {
           "properties": {
@@ -125,9 +104,7 @@
               "maxLength": 9
             }
           },
-          "required": [
-            "DUNS"
-          ]
+          "required": ["DUNS"]
         }
       ]
     },
@@ -147,9 +124,7 @@
               "$ref": "#/definitions/CompanyIdentifiers"
             }
           },
-          "required": [
-            "Identifiers"
-          ]
+          "required": ["Identifiers"]
         }
       ]
     }

--- a/key-value-object/key-value-object.json
+++ b/key-value-object/key-value-object.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/key-value-object/key-value-object.json",
+  "$id": "key-value-object.json",
   "definitions": {
     "KeyValueObject": {
       "title": "KeyValueObject",
@@ -19,19 +19,11 @@
           "type": "string"
         },
         "Type": {
-          "enum": [
-            "string",
-            "number",
-            "date",
-            "date-time",
-            "boolean"
-          ],
+          "enum": ["string", "number", "date", "date-time", "boolean"],
           "default": "string"
         }
       },
-      "required": [
-        "Key"
-      ],
+      "required": ["Key"],
       "additionalProperties": false
     }
   }

--- a/languages/languages.json
+++ b/languages/languages.json
@@ -1,28 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/languages/languages.json",
+  "$id": "languages.json",
   "definitions": {
     "CertificateLanguages": {
       "title": "CertificateLanguages",
       "description": "For a JSON document one or two translations used in the rendering of HTML and PDF documents can be specificed.",
       "type": "array",
       "items": {
-        "enum": [
-          "EN",
-          "DE",
-          "FR",
-          "ES",
-          "PL",
-          "CN",
-          "TR",
-          "IT"
-        ]
+        "enum": ["EN", "DE", "FR", "ES", "PL", "CN", "TR", "IT"]
       },
       "minItems": 1,
       "maxItems": 2,
-      "default": [
-        "EN"
-      ],
+      "default": ["EN"],
       "uniqueItems": true
     }
   }

--- a/measurement/measurement.json
+++ b/measurement/measurement.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/measurement/measurement.json",
+  "$id": "measurement.json",
   "definitions": {
     "Measurement": {
       "title": "Measurement",
@@ -28,9 +28,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "Value"
-      ],
+      "required": ["Value"],
       "additionalProperties": false
     }
   }

--- a/product-description/product-description.json
+++ b/product-description/product-description.json
@@ -1,18 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/product-description/product-description.json",
+  "$id": "product-description.json",
   "definitions": {
     "KeyValueObject": {
       "allOf": [
         {
-          "$ref": "https://schemas.s1seven.com/schema-definitions/v0.0.5/key-value-object/key-value-object.json#/definitions/KeyValueObject"
+          "$ref": "../key-value-object.json#/definitions/KeyValueObject"
         }
       ]
     },
     "Measurement": {
       "allOf": [
         {
-          "$ref": "https://schemas.s1seven.com/schema-definitions/v0.0.5/measurement/measurement.json#/definitions/Measurement"
+          "$ref": "../measurement.json#/definitions/Measurement"
         }
       ]
     },

--- a/ref-schema-url/README.md
+++ b/ref-schema-url/README.md
@@ -1,3 +1,3 @@
-RefSchemaUrl uses a regular expression to validate the urls. If the regex is updated, it can be tested against different valid and invalid strings in `test/regex.spec.js`. It can be tweaked or edited [here](https://regex101.com/r/gM5cU5/1) along with the test cases.
+RefSchemaUrl uses a regular expression to validate the urls. If the regex is updated, it can be tested against different valid and invalid strings in `test/regex.spec.js`. It can be tweaked or edited [here](https://regex101.com/r/BppqLe/1) along with the test cases.
 
 More information on the url structure can be found [here](https://s1seven.github.io/SEP/schemas/#versioning)

--- a/ref-schema-url/README.md
+++ b/ref-schema-url/README.md
@@ -1,1 +1,3 @@
 RefSchemaUrl uses a regular expression to validate the urls. If the regex is updated, it can be tested against different valid and invalid strings in `test/regex.spec.js`. It can be tweaked or edited [here](https://regex101.com/r/gM5cU5/1) along with the test cases.
+
+More information on the url structure can be found [here](https://s1seven.github.io/SEP/schemas/#versioning)

--- a/ref-schema-url/README.md
+++ b/ref-schema-url/README.md
@@ -1,0 +1,1 @@
+RefSchemaUrl uses a regular expression to validate the urls. If the regex is updated, it can be tested against different valid and invalid strings in `test/regex.spec.js`. It can be tweaked or edited [here](https://regex101.com/r/gM5cU5/1) along with the test cases.

--- a/ref-schema-url/ref-schema-url.json
+++ b/ref-schema-url/ref-schema-url.json
@@ -4,7 +4,7 @@
   "definitions": {
     "RefSchemaUrl": {
       "type": "string",
-      "pattern": "(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)"
+      "pattern": "(https?://[a-z0-9/\\.\\-]+[\\.a-z+])/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)"
     }
   }
 }

--- a/ref-schema-url/ref-schema-url.json
+++ b/ref-schema-url/ref-schema-url.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "ref-schema-url.json",
+  "definitions": {
+    "RefSchemaUrl": {
+      "type": "string",
+      "pattern": "(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)"
+    }
+  }
+}

--- a/ref-schema-url/test-schema.json
+++ b/ref-schema-url/test-schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "test-schema.json",
+  "type": "object",
+  "properties": {
+    "RefSchemaUrl": {
+      "allOf": [
+        {
+          "$ref": "ref-schema-url.json#/definitions/RefSchemaUrl"
+        }
+      ]
+    }
+  },
+  "required": ["RefSchemaUrl"]
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-1.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-1.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-10.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-10.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-11.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-11.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.3.x/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-12.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-12.json
@@ -1,3 +1,0 @@
-{
-  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.30/schema.json"
-}

--- a/ref-schema-url/test/fixtures/invalid-certificate-12.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-12.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.30/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-2.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-2.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-3.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-3.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.3.0/schema"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-4.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-4.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.3.0/schema.js"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-5.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-5.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.3.0/"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-6.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-6.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-7.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-7.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-8.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-8.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "www.schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-9.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-9.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.co.uk/en10168-schemas/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/invalid-certificate-9.json
+++ b/ref-schema-url/test/fixtures/invalid-certificate-9.json
@@ -1,3 +1,3 @@
 {
-  "RefSchemaUrl": "https://schemas.s1seven.co.uk/en10168-schemas/v0.3.0/schema.json"
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.30/schema.json"
 }

--- a/ref-schema-url/test/fixtures/valid-certificate-1.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-1.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-10.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-10.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/schema-definitions/v0.0.5/product-description/product-description.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-11.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-11.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/test/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-12.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-12.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/test/v0.22.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-13.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-13.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/test/v0.2.0-11/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-14.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-14.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.co.uk/en10168-schemas/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-2.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-2.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "http://schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-3.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-3.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.3.0-1/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-4.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-4.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/coa-schemas/v0.2.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-5.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-5.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/coa-schemas/v1.0.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-6.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-6.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/e-coc-schemas/v1.0.0/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-7.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-7.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/en10168-schemas/v0.0.2/schema.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-8.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-8.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/schema-definitions/v0.0.5/attachment/attachment.json"
+}

--- a/ref-schema-url/test/fixtures/valid-certificate-9.json
+++ b/ref-schema-url/test/fixtures/valid-certificate-9.json
@@ -1,0 +1,3 @@
+{
+  "RefSchemaUrl": "https://schemas.s1seven.com/schema-definitions/v0.0.5/key-value-object/key-value-object.json"
+}

--- a/ref-schema-url/test/regex.spec.js
+++ b/ref-schema-url/test/regex.spec.js
@@ -23,6 +23,9 @@ describe('tests valid strings against the RefSchemaUrl regexp', () => {
     'https://schemas.s1seven.com/test/v0.3.0/schema.json',
     'https://schemas.s1seven.com/test/v0.22.0/schema.json',
     'https://schemas.s1seven.com/test/v0.2.0-11/schema.json',
+    'https://schemas.s1seven.co.uk/en10168-schemas/v0.3.0/schema.json',
+    'https://schemas.s1seven.es/en10168-schemas/v0.3.0/schema.json',
+    'https://schemas.s1seven.gov/en10168-schemas/v0.3.0/schema.json',
   ];
   validStrings.forEach((string) => {
     it(`${string} is valid`, () => {
@@ -42,7 +45,6 @@ describe('tests invalid strings against the RefSchemaUrl regexp', () => {
     'https://schemas.s1seven.com/en10168-schemas/schema.json',
     'https://schemas.s1seven.com/v0.3.0/schema.json',
     'www.schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json',
-    'https://schemas.s1seven.co.uk/en10168-schemas/v0.3.0/schema.json',
     'https://schemas.s1seven.com/en10168-schemas/0.3.0/schema.json',
     'https://schemas.s1seven.com/en10168-schemas/v0.3.x/schema.json',
     'https://schemas.s1seven.com/en10168-schemas/v0.30/schema.json',

--- a/ref-schema-url/test/regex.spec.js
+++ b/ref-schema-url/test/regex.spec.js
@@ -1,0 +1,52 @@
+const regex = new RegExp(
+  '(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)',
+);
+
+describe('tests valid strings against the RefSchemaUrl regexp', () => {
+  const validStrings = [
+    'https://schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json',
+    'http://schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json',
+    'https://schemas.s1seven.com/coa-schemas/v0.2.0/schema.json',
+    'https://schemas.s1seven.com/coa-schemas/v0.2.0-1/schema.json',
+    'https://schemas.s1seven.com/coa-schemas/v0.2.0-5/schema.json',
+    'https://schemas.s1seven.com/coa-schemas/v1.0.0/schema.json',
+    'https://schemas.s1seven.com/coa-schemas/v1.0.1/schema.json',
+    'https://schemas.s1seven.com/e-coc-schemas/v1.0.0/schema.json',
+    'https://schemas.s1seven.com/en10168-schemas/v0.0.2/schema.json',
+    'https://schemas.s1seven.com/schema-definitions/v0.0.5/attachment/attachment.json',
+    'https://schemas.s1seven.com/schema-definitions/v0.0.5/key-value-object/key-value-object.json',
+    'https://schemas.s1seven.com/schema-definitions/v0.0.5/product-description/product-description.json',
+    'https://schemas.s1seven.com/test/v0.3.0/schema.json',
+    'https://schemas.s1seven.com/test/v0.22.0/schema.json',
+    'https://schemas.s1seven.com/test/v0.2.0-11/schema.json',
+  ];
+  validStrings.forEach((string) => {
+    it(`${string} is valid`, () => {
+      const matchedString = regex.exec(string)[0];
+      expect(matchedString).toBe(string);
+    });
+  });
+});
+
+describe('tests invalid strings against the RefSchemaUrl regexp', () => {
+  const invalidStrings = [
+    'schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json',
+    'https://schemas.s1seven.com/en10168-schemas/v0.0/schema.json',
+    'https://schemas.s1seven.com/en10168-schemas/v0.3.0/schema',
+    'https://schemas.s1seven.com/en10168-schemas/v0.3.0/schema.js',
+    'https://schemas.s1seven.com/en10168-schemas/v0.3.0/',
+    'https://schemas.s1seven.com/en10168-schemas/schema.json',
+    'https://schemas.s1seven.com/v0.3.0/schema.json',
+    'www.schemas.s1seven.com/en10168-schemas/v0.3.0/schema.json',
+    'https://schemas.s1seven.co.uk/en10168-schemas/v0.3.0/schema.json',
+    'https://schemas.s1seven.com/en10168-schemas/0.3.0/schema.json',
+    'https://schemas.s1seven.com/en10168-schemas/v0.3.x/schema.json',
+    'https://schemas.s1seven.com/en10168-schemas/v0.30/schema.json',
+  ];
+  invalidStrings.forEach((string) => {
+    it(`${string} is invalid`, () => {
+      const matchedString = regex.exec(string);
+      expect(matchedString).toBe(null);
+    });
+  });
+});

--- a/ref-schema-url/test/regex.spec.js
+++ b/ref-schema-url/test/regex.spec.js
@@ -1,6 +1,10 @@
-const regex = new RegExp(
-  '(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)',
-);
+const {
+  definitions: {
+    RefSchemaUrl: { pattern },
+  },
+} = require('../ref-schema-url.json');
+
+const regex = new RegExp(pattern);
 
 describe('tests valid strings against the RefSchemaUrl regexp', () => {
   const validStrings = [

--- a/ref-schema-url/test/test-suites-map.js
+++ b/ref-schema-url/test/test-suites-map.js
@@ -1,0 +1,80 @@
+const validCertTestSuitesMap = [
+  { certificateName: 'valid-certificate-1' },
+  { certificateName: 'valid-certificate-2' },
+  { certificateName: 'valid-certificate-3' },
+  { certificateName: 'valid-certificate-4' },
+  { certificateName: 'valid-certificate-5' },
+  { certificateName: 'valid-certificate-6' },
+  { certificateName: 'valid-certificate-7' },
+  { certificateName: 'valid-certificate-8' },
+  { certificateName: 'valid-certificate-9' },
+  { certificateName: 'valid-certificate-10' },
+  { certificateName: 'valid-certificate-11' },
+  { certificateName: 'valid-certificate-12' },
+  { certificateName: 'valid-certificate-13' },
+];
+
+const patternErrorObject = {
+  instancePath: '/RefSchemaUrl',
+  schemaPath: 'ref-schema-url.json#/definitions/RefSchemaUrl/pattern',
+  keyword: 'pattern',
+  params: {
+    pattern:
+      '(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)',
+  },
+  message:
+    'must match pattern "(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)"',
+};
+
+const invalidCertTestSuitesMap = [
+  {
+    certificateName: 'invalid-certificate-1',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-2',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-3',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-4',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-5',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-6',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-7',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-8',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-9',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-10',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-11',
+    expectedErrors: [patternErrorObject],
+  },
+  {
+    certificateName: 'invalid-certificate-12',
+    expectedErrors: [patternErrorObject],
+  },
+];
+
+module.exports = { validCertTestSuitesMap, invalidCertTestSuitesMap };

--- a/ref-schema-url/test/test-suites-map.js
+++ b/ref-schema-url/test/test-suites-map.js
@@ -12,6 +12,7 @@ const validCertTestSuitesMap = [
   { certificateName: 'valid-certificate-11' },
   { certificateName: 'valid-certificate-12' },
   { certificateName: 'valid-certificate-13' },
+  { certificateName: 'valid-certificate-14' },
 ];
 
 const patternErrorObject = {
@@ -20,10 +21,10 @@ const patternErrorObject = {
   keyword: 'pattern',
   params: {
     pattern:
-      '(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)',
+      '(https?://[a-z0-9/\\.\\-]+[\\.a-z+])/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)',
   },
   message:
-    'must match pattern "(https?://[a-z0-9/\\.\\-]+[\\.]com)/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)"',
+    'must match pattern "(https?://[a-z0-9/\\.\\-]+[\\.a-z+])/([a-z0-9\\-]+)/(v\\d+\\.\\d+\\.\\d+(-\\d+)?)/([a-z\\./\\-]+.json)"',
 };
 
 const invalidCertTestSuitesMap = [
@@ -69,10 +70,6 @@ const invalidCertTestSuitesMap = [
   },
   {
     certificateName: 'invalid-certificate-11',
-    expectedErrors: [patternErrorObject],
-  },
-  {
-    certificateName: 'invalid-certificate-12',
     expectedErrors: [patternErrorObject],
   },
 ];

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -7,6 +7,7 @@ const folders = [
   'languages',
   'measurement',
   'product-description',
+  'ref-schema-url',
   'validation',
 ];
 

--- a/utils/test/helpers.spec.js
+++ b/utils/test/helpers.spec.js
@@ -76,11 +76,13 @@ describe('setLocalIds() should generate local ids', function () {
 });
 
 describe('commitChanges() should correctly set the commit message', function () {
+  const log = jest.spyOn(console, 'log').mockImplementation(() => {});
   commitChanges('test');
 
   it('the commit message should be correctly set', () => {
     expect(child_process.execSync).toHaveBeenCalledWith(
       `git commit -m 'test' --no-verify`,
     );
+    expect(log).toBeCalledWith('Staged files have been commited.');
   });
 });

--- a/utils/update-version.js
+++ b/utils/update-version.js
@@ -57,6 +57,10 @@ const schemaFilePaths = [
     ],
   },
   {
+    filePath: 'ref-schema-url/ref-schema-url.json',
+    properties: [{ path: '$id', value: 'ref-schema-url/ref-schema-url.json' }],
+  },
+  {
     filePath: 'validation/validation.json',
     properties: [{ path: '$id', value: 'validation/validation.json' }],
   },

--- a/validate.spec.js
+++ b/validate.spec.js
@@ -14,6 +14,7 @@ const folders = [
   'languages',
   'measurement',
   'product-description',
+  'ref-schema-url',
   'validation',
 ];
 

--- a/validation/validation.json
+++ b/validation/validation.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://schemas.s1seven.com/schema-definitions/v0.0.5/validation/validation.json",
+  "$id": "validation.json",
   "definitions": {
     "KeyValueObject": {
       "allOf": [
         {
-          "$ref": "https://schemas.s1seven.com/schema-definitions/v0.0.5/key-value-object/key-value-object.json#/definitions/KeyValueObject"
+          "$ref": "../key-value-object.json#/definitions/KeyValueObject"
         }
       ]
     },


### PR DESCRIPTION
# Description

Adds a `RefSchemaUrl` definition, using a regex to validate the urls.
Improves `helpers` tests by mocking `console.log`, cleaning up the console.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] ⚠️ I ensured that the changes to the schema will be compatible with [schema-tools library](https://github.com/s1seven/schema-tools)
