### PR TITLE
fix: add missing table-cells css class to tr

### DIFF
--- a/commercial-transaction/commercial-transaction.hbs
+++ b/commercial-transaction/commercial-transaction.hbs
@@ -30,7 +30,7 @@
         <td class="table-cells">
           <img class="image" src="{{CommercialTransaction.A04}}" />
         </td>
-        <td>
+        <td class="table-cells">
           {{> company CommercialTransaction.A01 }}
         </td>
         {{#if CommercialTransaction.A06}}


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
-->

One of the `tr`s in commercial-transaction did not have the `table-cells` class applied. This PR adds that class which adds a little padding between the logo and the next element in the row, improving the layout.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] ⚠️ I ensured that the changes to the schema will be compatible with [schema-tools library](https://github.com/s1seven/schema-tools)

Before:
﻿﻿
![image](https://github.com/material-identity/schema-definitions/assets/21305201/5575170e-ee22-4731-aa0f-affbf82ff6fd)

After:
![image](https://github.com/material-identity/schema-definitions/assets/21305201/f20c2b86-8657-4d88-abf8-17a0fd7029f9)

